### PR TITLE
feat: add DEVSPACE_USERNAME to assist migration from DevSpace Cloud

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -69,6 +69,8 @@ vars:
     baseArgs: ["vars", "cluster"]
   - name: LOFT_USERNAME
     baseArgs: ["vars", "username"]
+  - name: DEVSPACE_USERNAME
+    baseArgs: ["vars", "username"]
 binaries:
   - os: darwin
     arch: amd64


### PR DESCRIPTION
Adds the `DEVSPACE_USERNAME` var to assist users that are migrating from DevSpace Cloud